### PR TITLE
Improved clarity of HelloWorld class' default object

### DIFF
--- a/src/metrocs/HelloWorld.java
+++ b/src/metrocs/HelloWorld.java
@@ -19,8 +19,8 @@ public class HelloWorld {
    * @param args ignored
    */
   public static void main(final String[] args) {
-    HelloWorld hw = new HelloWorld();
-    System.out.println(hw.sayHello("world"));
+    HelloWorld defaultHW = new HelloWorld();
+    System.out.println(defaultHW.sayHello("world"));
   }
 
   /**


### PR DESCRIPTION
Changed the default object of the HelloWorld class to a more descriptive name than "hw". Possibly unnecessary given the target demographic of this code is individuals who will understand what "hw" is without cleanly written object names.